### PR TITLE
Remove duplicate declaration of Client and Session

### DIFF
--- a/src/mysqlx.ts
+++ b/src/mysqlx.ts
@@ -15,9 +15,10 @@
 
 // @ts-ignore
 import mysql from '@mysql/xdevapi'
+import ClientClass from './Client';
+import SessionClass from './Session';
 import * as Types from './types'
 import * as Interfaces from './interfaces'
-
 export type Client = Interfaces.IClient
 export type Collection = Interfaces.ICollection
 export type CollectionAdd = Interfaces.ICollectionAdd
@@ -72,14 +73,14 @@ export function expr(expression: Expression, options?: ParserOptions): ProtobufO
 	return mysql.expr(expression, options)
 }
 
-export function getClient(connection: ConnectionOptions, pooling: PoolingOptions): Client {
-	return new Client(connection, pooling)
+export function getClient(connection: ConnectionOptions, pooling: PoolingOptions): ClientClass {
+	return new ClientClass(connection, pooling)
 }
 
-export async function getSession(connection: ConnectionOptions): Promise<Session> {
+export async function getSession(connection: ConnectionOptions): Promise<SessionClass> {
 	try {
 		const xSession = await mysql.getSession(connection)
-		return new Session(null, xSession)
+		return new SessionClass(null, xSession)
 	} catch (error) {
 		throw error
 	}

--- a/src/mysqlx.ts
+++ b/src/mysqlx.ts
@@ -15,8 +15,6 @@
 
 // @ts-ignore
 import mysql from '@mysql/xdevapi'
-import Client from './Client'
-import Session from './Session'
 import * as Types from './types'
 import * as Interfaces from './interfaces'
 


### PR DESCRIPTION
The Client and Session exports were imported in two different places, i.e. from ./Client and ./Session as well as from ./interfaces.
So, removing the imports on from ./Client and ./Session fixed the issue